### PR TITLE
Fix anisongdb error

### DIFF
--- a/amqTrainingMode.user.js
+++ b/amqTrainingMode.user.js
@@ -4876,7 +4876,7 @@ async function getMalIdsFromMyanimelist(username) {
             } else {
                 for (let anime of result.data) {
                      const malIdEntry = {
-                         malId: anime.nodeId,
+                         malId: anime.node.id,
                      };
                     malIds.push(malIdEntry);
                 }


### PR DESCRIPTION
`anime.nodeId` is undefined, resulting in an error when trying to import the songs from anisongdb. It should instead be `anime.node.id`