### PR TITLE
Fix AMQ Export

### DIFF
--- a/amqTrainingMode.user.js
+++ b/amqTrainingMode.user.js
@@ -5575,12 +5575,12 @@ function handleData(data) {
         animeGenre: song.songInfo.animeGenre ?? [],
         rebroadcast: null,
         dub: null,
-        startPoint: song.songInfo.startPoint,
+        startPoint: song.startPoint,
         audio: null,
         video480: null,
-        video720: null,
-        correctGuess: !song.songInfo.wrongGuess,
-        incorrectGuess: song.songInfo.wrongGuess,
+        video720: song.videoUrl ?? null,
+        correctGuess: !song.wrongGuess,
+        incorrectGuess: song.wrongGuess,
         rating: null,
       });
     }

--- a/types/amqexport.d.ts
+++ b/types/amqexport.d.ts
@@ -5,8 +5,6 @@ type AMQSong = {
       english: string;
       romaji: string;
     };
-    altAnimeNames: string[];
-    altAnimeNamesAnswers: string[];
     artist: string;
     songName: string;
     type: number;
@@ -16,22 +14,33 @@ type AMQSong = {
     animeType: string; // e.g. "OVA"
     vintage: string; // e.g. "Fall 2016"
     animeDifficulty: number;
+    animeTags: string[];
+    animeGenre: string[];
+    altAnimeNames: string[];
+    altAnimeNamesAnswers: string[];
     siteIds: {
       annId: number;
       malId: number;
       kitsuId: number;
       aniListId: number;
     };
-    animeTags: string[];
-    animeGenre: string[];
-    answer: string;
-    correctGuess: number;
-    wrongGuess: boolean;
-    correctCount: number;
-    wrongCount: number;
-    startPoint: number;
-    videoLength: number;
+    rebroadcast?: number;
+    dub?: number;
   };
+  correctGuess: boolean;
+  wrongGuess: boolean;
+  answer: string;
+  correctCount: number;
+  wrongCount: number;
+  startPoint: number;
+  videoLength: number;
+  videoUrl?: string;
+  correctGuessPlayers?: string[];
+  listStates?: {
+    name: string;
+    status: number;
+    score: number;
+  }[];
 };
 
 export type AMQExport = {


### PR DESCRIPTION
Fixed the types, and the bug where importing an official AMQ export would not work (with error "0 song links found").

**Note**: AMQ exports work only if downloaded from the same session. If you load them after, they will not contain video links. I added this finding to the types, by denoting the `videoLink` as possibly undefined.