### PR TITLE
Fix startPont -> startPoint

### DIFF
--- a/amqTrainingMode.user.js
+++ b/amqTrainingMode.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         AMQ Training Mode
 // @namespace    https://github.com/4Lajf
-// @version      0.83
+// @version      0.84
 // @description  Extended version of kempanator's Custom Song List Game Training mode allows you to practice your songs efficiently something line anki or other memory card software. It's goal is to give you songs that you don't recozniged mixed with some songs that you do recognize to solidify them in your memory.
 // @match        https://*.animemusicquiz.com/*
 // @author       4Lajf & kempanator

--- a/amqTrainingMode.user.js
+++ b/amqTrainingMode.user.js
@@ -3776,7 +3776,7 @@ function startQuiz() {
       fireListener("quiz next video info", {
         playLength: guessTime,
         playbackSpeed: 1,
-        startPont: getStartPoint(),
+        startPoint: getStartPoint(),
         videoInfo: {
           id: -1,
           videoMap: {
@@ -3913,7 +3913,7 @@ function playSong(songNumber) {
         fireListener("quiz next video info", {
           playLength: guessTime,
           playbackSpeed: 1,
-          startPont: getStartPoint(),
+          startPoint: getStartPoint(),
           videoInfo: {
             id: -1,
             videoMap: {
@@ -4514,7 +4514,7 @@ function parseMessage(content, sender) {
             fireListener("quiz next video info", {
               playLength: guessTime,
               playbackSpeed: 1,
-              startPont: parseInt(split[1]),
+              startPoint: parseInt(split[1]),
               videoInfo: {
                 id: -1,
                 videoMap: {

--- a/types.d.ts
+++ b/types.d.ts
@@ -283,7 +283,7 @@ export type QuizUnpausedPayload = {
 export type QuizNextVideoInfoPayload = {
   playbackSpeed: number;
   playLength: number;
-  startPont: number;
+  startPoint: number;
   videoInfo: {
     id: number;
     videoMap: { catbox: VideoMap };


### PR DESCRIPTION
Fixes this error:

```
VIDEOJS: TypeError: Failed to set the 'currentTime' property on 'HTMLMediaElement': The provided double value is non-finite.
    at e.setCurrentTime (video.min.js:12:177678)
    at video.min.js:12:204043
    at l.<anonymous> (video.min.js:12:204063)
    at e.ready (video.min.js:12:19716)
    at e.techCall_ (video.min.js:12:203979)
    at e.currentTime (video.min.js:12:206018)
    at MoeVideoPlayer.handleLoadMetaData (moeVideoPlayer.js:55:15)
    at l.<anonymous> (videoPlayer.js:57:9)
    at o.dispatcher.o.dispatcher (video.min.js:12:9892)
    at le (video.min.js:12:10670) Video is not ready. (Video.js)
```

The API has changed and now `startPont` is named `startPoint`. 